### PR TITLE
Unit test for Ho Chi Minh.

### DIFF
--- a/src/country-time.coffee
+++ b/src/country-time.coffee
@@ -97,7 +97,7 @@ infoFromLocation = (location) ->
 
   # Search timezones for match
   for zone in moment.tz.names()
-    city = zone.replace(/.*\//,'')
+    city = zone.replace(/.*\//,'').replace(/_/g, ' ')
     s = city.toLowerCase().score(location.toLowerCase(), 0.001)
     if s > 0.40 && s > best.score
       best =

--- a/test/country-time-test.coffee
+++ b/test/country-time-test.coffee
@@ -78,6 +78,12 @@ describe 'country-time', ->
     @robot.respond.args[0][1](@msg)
     expect(@msg.send).to.have.been.calledWithMatch(/^It's .* in Helsingborg right now/)
 
+  it 'responds to "time in Ho Chi Minh" with the city', ->
+    @msg.match = [0, 'time', 'Ho Chi Minh']
+    @robot.respond.args[0][1](@msg)
+    expect(@msg.send).to.have.been.calledWithMatch(/^It's .* in Ho Chi Minh right now/)
+
+
   it 'responds to "time in Area51" with unknown', ->
     @msg.match = [0, 'time', 'Area51']
     @robot.respond.args[0][1](@msg)


### PR DESCRIPTION
Fix the code to match cities that have one or more spaces in the name (like Ho_Chi_Minh). These have underscores in their timezone name. 
